### PR TITLE
fix: job image axios error, replace base image

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-slim
  
 WORKDIR /app
  


### PR DESCRIPTION
cronjob 실습 중 사용하는 Dockerfile.worker에서도 이전과 동일한 axios 에러가 발생해서 base 이미지를 수정했어요.